### PR TITLE
DPR2-901 configuration table to limit tables written to ods

### DIFF
--- a/migrations/development/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
+++ b/migrations/development/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS configuration;
+
+CREATE TABLE configuration.datahub_managed_tables
+(
+    source     VARCHAR,
+    table_name VARCHAR,
+    PRIMARY KEY (source, table_name)
+);
+
+INSERT INTO configuration.datahub_managed_tables (source, table_name)
+VALUES ('nomis', 'offenders'),
+       ('nomis', 'offender_bookings'),
+       ('nomis', 'offender_profile_details'),
+       ('nomis', 'profile_codes'),
+       ('nomis', 'offender_identifiers'),
+       ('nomis', 'offender_languages'),
+       ('nomis', 'offender_sentence_terms'),
+       ('nomis', 'reference_codes'),
+       ('nomis', 'offender_assessments');

--- a/migrations/preproduction/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
+++ b/migrations/preproduction/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS configuration;
+
+CREATE TABLE configuration.datahub_managed_tables
+(
+    source     VARCHAR,
+    table_name VARCHAR,
+    PRIMARY KEY (source, table_name)
+);
+
+INSERT INTO configuration.datahub_managed_tables (source, table_name)
+VALUES ('nomis', 'offenders'),
+       ('nomis', 'offender_bookings'),
+       ('nomis', 'offender_profile_details'),
+       ('nomis', 'profile_codes'),
+       ('nomis', 'offender_identifiers'),
+       ('nomis', 'offender_languages'),
+       ('nomis', 'offender_sentence_terms'),
+       ('nomis', 'reference_codes'),
+       ('nomis', 'offender_assessments');

--- a/migrations/production/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
+++ b/migrations/production/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS configuration;
+
+CREATE TABLE configuration.datahub_managed_tables
+(
+    source     VARCHAR,
+    table_name VARCHAR,
+    PRIMARY KEY (source, table_name)
+);
+
+INSERT INTO configuration.datahub_managed_tables (source, table_name)
+VALUES ('nomis', 'offenders'),
+       ('nomis', 'offender_bookings'),
+       ('nomis', 'offender_profile_details'),
+       ('nomis', 'profile_codes'),
+       ('nomis', 'offender_identifiers'),
+       ('nomis', 'offender_languages'),
+       ('nomis', 'offender_sentence_terms'),
+       ('nomis', 'reference_codes'),
+       ('nomis', 'offender_assessments');

--- a/migrations/test/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
+++ b/migrations/test/operationaldatastore/sql/V002__create-configuration-to-manage-tables.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS configuration;
+
+CREATE TABLE configuration.datahub_managed_tables
+(
+    source     VARCHAR,
+    table_name VARCHAR,
+    PRIMARY KEY (source, table_name)
+);
+
+INSERT INTO configuration.datahub_managed_tables (source, table_name)
+VALUES ('nomis', 'offenders'),
+       ('nomis', 'offender_bookings'),
+       ('nomis', 'offender_profile_details'),
+       ('nomis', 'profile_codes'),
+       ('nomis', 'offender_identifiers'),
+       ('nomis', 'offender_languages'),
+       ('nomis', 'offender_sentence_terms'),
+       ('nomis', 'reference_codes'),
+       ('nomis', 'offender_assessments');


### PR DESCRIPTION
- Adds a configuration table with reference data configuring the datahub tables managed in the Operational DataStore