### PR TITLE
DPR2-899: Refresh prisoner_prisoner daily at 2am.

### DIFF
--- a/migrations/development/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
+++ b/migrations/development/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 'REFRESH MATERIALIZED VIEW CONCURRENTLY' requires a unique index
+CREATE UNIQUE INDEX prisoner_prisoner_id_key ON domain.prisoner_prisoner(id);
+
+-- Refresh daily at 2am. Refreshing concurrently allows queries to continue during the refresh
+SELECT cron.schedule ('refresh domain.prisoner_prisoner','0 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY domain.prisoner_prisoner');

--- a/migrations/preproduction/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
+++ b/migrations/preproduction/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 'REFRESH MATERIALIZED VIEW CONCURRENTLY' requires a unique index
+CREATE UNIQUE INDEX prisoner_prisoner_id_key ON domain.prisoner_prisoner(id);
+
+-- Refresh daily at 2am. Refreshing concurrently allows queries to continue during the refresh
+SELECT cron.schedule ('refresh domain.prisoner_prisoner','0 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY domain.prisoner_prisoner');

--- a/migrations/production/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
+++ b/migrations/production/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 'REFRESH MATERIALIZED VIEW CONCURRENTLY' requires a unique index
+CREATE UNIQUE INDEX prisoner_prisoner_id_key ON domain.prisoner_prisoner(id);
+
+-- Refresh daily at 2am. Refreshing concurrently allows queries to continue during the refresh
+SELECT cron.schedule ('refresh domain.prisoner_prisoner','0 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY domain.prisoner_prisoner');

--- a/migrations/test/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
+++ b/migrations/test/operationaldatastore/sql/V005__cron-refresh-prisoner-prisoner-materialised-view.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 'REFRESH MATERIALIZED VIEW CONCURRENTLY' requires a unique index
+CREATE UNIQUE INDEX prisoner_prisoner_id_key ON domain.prisoner_prisoner(id);
+
+-- Refresh daily at 2am. Refreshing concurrently allows queries to continue during the refresh
+SELECT cron.schedule ('refresh domain.prisoner_prisoner','0 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY domain.prisoner_prisoner');


### PR DESCRIPTION
- Ensure pg_cron is installed
- Create a unique index for the prisoner_prisoner domain materialised view
- Concurrently refresh the prisoner_prisoner domain materialised view at 2am each day