### PR TITLE
DPR2-1041 and DPR2-1040: Update domain

### DIFF
--- a/migrations/development/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
+++ b/migrations/development/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
@@ -3,7 +3,6 @@
 -- =================================================================
 
 CREATE SCHEMA IF NOT EXISTS domain;
-
 DROP MATERIALIZED VIEW IF EXISTS domain.prisoner_prisoner;
 
 CREATE MATERIALIZED VIEW domain.prisoner_prisoner AS
@@ -13,7 +12,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                       prisons.nomis_profile_codes.description
                FROM prisons.nomis_offender_profile_details
                         LEFT JOIN prisons.nomis_profile_codes ON prisons.nomis_profile_codes.profile_code =
-                                                         prisons.nomis_offender_profile_details.profile_code
+                                                                 prisons.nomis_offender_profile_details.profile_code
                where prisons.nomis_offender_profile_details.profile_type = 'RELF'),
      pnc AS (SELECT *, row_number() over (partition by offender_id order by offender_id_seq) as rn
              FROM prisons.nomis_offender_identifiers
@@ -29,7 +28,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                           where domain = 'ETHNICITY'),
      nationality_info AS (select row_number() over (partition by offender_book_id) as rn,
                                  offender_book_id,
-                                 prisons.nomis_profile_codes.profile_code                  as code,
+                                 prisons.nomis_profile_codes.profile_code          as code,
                                  prisons.nomis_profile_codes.description
                           from prisons.nomis_offender_profile_details
                                    left join prisons.nomis_profile_codes
@@ -39,7 +38,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
      gender_domain AS (SELECT code, domain, description from prisons.nomis_reference_codes where domain = 'SEX'),
      diet_info AS (select row_number() over (partition by offender_book_id) as rn,
                           offender_book_id,
-                          prisons.nomis_profile_codes.profile_code                  as code,
+                          prisons.nomis_profile_codes.profile_code          as code,
                           prisons.nomis_profile_codes.description
                    from prisons.nomis_offender_profile_details
                             left join prisons.nomis_profile_codes
@@ -55,51 +54,41 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                     prisons.nomis_profile_codes.description
              from prisons.nomis_offender_profile_details
                       left join prisons.nomis_profile_codes on prisons.nomis_offender_profile_details.profile_code =
-                                                       prisons.nomis_profile_codes.profile_code
+                                                               prisons.nomis_profile_codes.profile_code
              where prisons.nomis_offender_profile_details.profile_type = 'SEXO')
-SELECT o.offender_id_display                                  AS number,
-       ob.offender_book_id                                    AS id,
-       o.offender_id                                          AS offender_id,
-       o.root_offender_id                                     AS offender_root_id,
-       ob.agy_loc_id                                          AS establishment_id,
-       ob.living_unit_id                                      AS living_unit_id,
-       o.first_name                                           AS first_name,
-       o.middle_name                                          AS middle_name,
-       o.middle_name_2                                        AS middle_name_2,
-       o.last_name                                            AS last_name,
-       o.suffix                                               AS suffix,
-       (o.last_name || ', ' || substring(o.first_name, 1, 1)) AS name,
-       ob.request_name                                        AS requested_name,
-       o.birth_date                                           AS date_of_birth,
-       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))  AS age,
-       o.birth_place                                          AS birth_place,
-       o.sex_code                                             AS gender_code,
-       gender_domain.description                              AS gender,
+SELECT o.offender_id_display                                      AS number,
+       ob.offender_book_id                                        AS id,
+       o.offender_id                                              AS offender_id,
+       o.root_offender_id                                         AS offender_root_id,
+       ob.agy_loc_id                                              AS establishment_id,
+       ob.living_unit_id                                          AS living_unit_id,
+       o.first_name                                               AS first_name,
+       o.middle_name                                              AS middle_name,
+       o.middle_name_2                                            AS middle_name_2,
+       o.last_name                                                AS last_name,
+       o.suffix                                                   AS suffix,
+       (o.last_name || ', ' || substring(o.first_name, 1, 1))     AS name,
+       ob.request_name                                            AS requested_name,
+       o.birth_date                                               AS date_of_birth,
+       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))::int AS age,
+       o.birth_place                                              AS birth_place,
+       o.sex_code                                                 AS gender_code,
+       gender_domain.description                                  AS gender,
        CASE
            WHEN o.race_code = 'W8' then 'W3'
            WHEN o.race_code = 'O1' then 'A4'
-           ELSE o.race_code END                               AS ethnicity_code,
-       ethnicity_domain.description                           AS ethnicity,
-       prim_lang.language_code                                AS primary_language,
-       sec_lang.language_code                                 AS secondary_language,
-       pnc.identifier                                         AS pnc,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'LIFE'
-           ELSE (latest_sentence.years || '/' || latest_sentence.months || '/' ||
-                 latest_sentence.days) END                    AS sentence_length,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'Life'
-           ELSE (latest_sentence.years || ' years ' || latest_sentence.months || ' months ' || latest_sentence.days ||
-                 ' days') END                                 AS sentence_length_description,
-       nationality_info.code                                  AS nationality_code,
-       nationality_info.description                           AS nationality,
-       ofrel.profile_code                                     AS religion_code,
-       ofrel.description                                      AS religion,
-       latest_category.score                                  AS category,
-       diet_info.code                                         AS diet_code,
-       diet_info.description                                  AS diet,
-       sexo_info.code                                         AS sex_orientation_code,
-       sexo_info.description                                  AS sex_orientation
+           ELSE o.race_code END                                   AS ethnicity_code,
+       ethnicity_domain.description                               AS ethnicity,
+       prim_lang.language_code                                    AS primary_language,
+       pnc.identifier                                             AS pnc,
+       nationality_info.code                                      AS nationality_code,
+       nationality_info.description                               AS nationality,
+       ofrel.profile_code                                         AS religion_code,
+       ofrel.description                                          AS religion,
+       diet_info.code                                             AS diet_code,
+       diet_info.description                                      AS diet,
+       sexo_info.code                                             AS sex_orientation_code,
+       sexo_info.description                                      AS sex_orientation
 FROM prisons.nomis_offenders o
          JOIN prisons.nomis_offender_bookings ob ON o.offender_id = ob.offender_id
          LEFT JOIN ofrel ON ofrel.offender_book_id = ob.offender_book_id AND ofrel.rn = 1
@@ -114,3 +103,5 @@ FROM prisons.nomis_offenders o
          LEFT JOIN diet_info ON ob.offender_book_id = diet_info.offender_book_id AND diet_info.rn = 1
          LEFT JOIN latest_category ON latest_category.offender_book_id = ob.offender_book_id AND latest_category.rn = 1
          LEFT JOIN sexo_info ON ob.offender_book_id = sexo_info.offender_book_id AND sexo_info.rn = 1;
+
+

--- a/migrations/development/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
+++ b/migrations/development/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
@@ -103,5 +103,3 @@ FROM prisons.nomis_offenders o
          LEFT JOIN diet_info ON ob.offender_book_id = diet_info.offender_book_id AND diet_info.rn = 1
          LEFT JOIN latest_category ON latest_category.offender_book_id = ob.offender_book_id AND latest_category.rn = 1
          LEFT JOIN sexo_info ON ob.offender_book_id = sexo_info.offender_book_id AND sexo_info.rn = 1;
-
-

--- a/migrations/preproduction/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
+++ b/migrations/preproduction/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
@@ -3,7 +3,6 @@
 -- =================================================================
 
 CREATE SCHEMA IF NOT EXISTS domain;
-
 DROP MATERIALIZED VIEW IF EXISTS domain.prisoner_prisoner;
 
 CREATE MATERIALIZED VIEW domain.prisoner_prisoner AS
@@ -13,7 +12,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                       prisons.nomis_profile_codes.description
                FROM prisons.nomis_offender_profile_details
                         LEFT JOIN prisons.nomis_profile_codes ON prisons.nomis_profile_codes.profile_code =
-                                                         prisons.nomis_offender_profile_details.profile_code
+                                                                 prisons.nomis_offender_profile_details.profile_code
                where prisons.nomis_offender_profile_details.profile_type = 'RELF'),
      pnc AS (SELECT *, row_number() over (partition by offender_id order by offender_id_seq) as rn
              FROM prisons.nomis_offender_identifiers
@@ -29,7 +28,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                           where domain = 'ETHNICITY'),
      nationality_info AS (select row_number() over (partition by offender_book_id) as rn,
                                  offender_book_id,
-                                 prisons.nomis_profile_codes.profile_code                  as code,
+                                 prisons.nomis_profile_codes.profile_code          as code,
                                  prisons.nomis_profile_codes.description
                           from prisons.nomis_offender_profile_details
                                    left join prisons.nomis_profile_codes
@@ -39,7 +38,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
      gender_domain AS (SELECT code, domain, description from prisons.nomis_reference_codes where domain = 'SEX'),
      diet_info AS (select row_number() over (partition by offender_book_id) as rn,
                           offender_book_id,
-                          prisons.nomis_profile_codes.profile_code                  as code,
+                          prisons.nomis_profile_codes.profile_code          as code,
                           prisons.nomis_profile_codes.description
                    from prisons.nomis_offender_profile_details
                             left join prisons.nomis_profile_codes
@@ -55,51 +54,41 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                     prisons.nomis_profile_codes.description
              from prisons.nomis_offender_profile_details
                       left join prisons.nomis_profile_codes on prisons.nomis_offender_profile_details.profile_code =
-                                                       prisons.nomis_profile_codes.profile_code
+                                                               prisons.nomis_profile_codes.profile_code
              where prisons.nomis_offender_profile_details.profile_type = 'SEXO')
-SELECT o.offender_id_display                                  AS number,
-       ob.offender_book_id                                    AS id,
-       o.offender_id                                          AS offender_id,
-       o.root_offender_id                                     AS offender_root_id,
-       ob.agy_loc_id                                          AS establishment_id,
-       ob.living_unit_id                                      AS living_unit_id,
-       o.first_name                                           AS first_name,
-       o.middle_name                                          AS middle_name,
-       o.middle_name_2                                        AS middle_name_2,
-       o.last_name                                            AS last_name,
-       o.suffix                                               AS suffix,
-       (o.last_name || ', ' || substring(o.first_name, 1, 1)) AS name,
-       ob.request_name                                        AS requested_name,
-       o.birth_date                                           AS date_of_birth,
-       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))  AS age,
-       o.birth_place                                          AS birth_place,
-       o.sex_code                                             AS gender_code,
-       gender_domain.description                              AS gender,
+SELECT o.offender_id_display                                      AS number,
+       ob.offender_book_id                                        AS id,
+       o.offender_id                                              AS offender_id,
+       o.root_offender_id                                         AS offender_root_id,
+       ob.agy_loc_id                                              AS establishment_id,
+       ob.living_unit_id                                          AS living_unit_id,
+       o.first_name                                               AS first_name,
+       o.middle_name                                              AS middle_name,
+       o.middle_name_2                                            AS middle_name_2,
+       o.last_name                                                AS last_name,
+       o.suffix                                                   AS suffix,
+       (o.last_name || ', ' || substring(o.first_name, 1, 1))     AS name,
+       ob.request_name                                            AS requested_name,
+       o.birth_date                                               AS date_of_birth,
+       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))::int AS age,
+       o.birth_place                                              AS birth_place,
+       o.sex_code                                                 AS gender_code,
+       gender_domain.description                                  AS gender,
        CASE
            WHEN o.race_code = 'W8' then 'W3'
            WHEN o.race_code = 'O1' then 'A4'
-           ELSE o.race_code END                               AS ethnicity_code,
-       ethnicity_domain.description                           AS ethnicity,
-       prim_lang.language_code                                AS primary_language,
-       sec_lang.language_code                                 AS secondary_language,
-       pnc.identifier                                         AS pnc,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'LIFE'
-           ELSE (latest_sentence.years || '/' || latest_sentence.months || '/' ||
-                 latest_sentence.days) END                    AS sentence_length,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'Life'
-           ELSE (latest_sentence.years || ' years ' || latest_sentence.months || ' months ' || latest_sentence.days ||
-                 ' days') END                                 AS sentence_length_description,
-       nationality_info.code                                  AS nationality_code,
-       nationality_info.description                           AS nationality,
-       ofrel.profile_code                                     AS religion_code,
-       ofrel.description                                      AS religion,
-       latest_category.score                                  AS category,
-       diet_info.code                                         AS diet_code,
-       diet_info.description                                  AS diet,
-       sexo_info.code                                         AS sex_orientation_code,
-       sexo_info.description                                  AS sex_orientation
+           ELSE o.race_code END                                   AS ethnicity_code,
+       ethnicity_domain.description                               AS ethnicity,
+       prim_lang.language_code                                    AS primary_language,
+       pnc.identifier                                             AS pnc,
+       nationality_info.code                                      AS nationality_code,
+       nationality_info.description                               AS nationality,
+       ofrel.profile_code                                         AS religion_code,
+       ofrel.description                                          AS religion,
+       diet_info.code                                             AS diet_code,
+       diet_info.description                                      AS diet,
+       sexo_info.code                                             AS sex_orientation_code,
+       sexo_info.description                                      AS sex_orientation
 FROM prisons.nomis_offenders o
          JOIN prisons.nomis_offender_bookings ob ON o.offender_id = ob.offender_id
          LEFT JOIN ofrel ON ofrel.offender_book_id = ob.offender_book_id AND ofrel.rn = 1

--- a/migrations/production/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
+++ b/migrations/production/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
@@ -3,7 +3,6 @@
 -- =================================================================
 
 CREATE SCHEMA IF NOT EXISTS domain;
-
 DROP MATERIALIZED VIEW IF EXISTS domain.prisoner_prisoner;
 
 CREATE MATERIALIZED VIEW domain.prisoner_prisoner AS
@@ -13,7 +12,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                       prisons.nomis_profile_codes.description
                FROM prisons.nomis_offender_profile_details
                         LEFT JOIN prisons.nomis_profile_codes ON prisons.nomis_profile_codes.profile_code =
-                                                         prisons.nomis_offender_profile_details.profile_code
+                                                                 prisons.nomis_offender_profile_details.profile_code
                where prisons.nomis_offender_profile_details.profile_type = 'RELF'),
      pnc AS (SELECT *, row_number() over (partition by offender_id order by offender_id_seq) as rn
              FROM prisons.nomis_offender_identifiers
@@ -29,7 +28,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                           where domain = 'ETHNICITY'),
      nationality_info AS (select row_number() over (partition by offender_book_id) as rn,
                                  offender_book_id,
-                                 prisons.nomis_profile_codes.profile_code                  as code,
+                                 prisons.nomis_profile_codes.profile_code          as code,
                                  prisons.nomis_profile_codes.description
                           from prisons.nomis_offender_profile_details
                                    left join prisons.nomis_profile_codes
@@ -39,7 +38,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
      gender_domain AS (SELECT code, domain, description from prisons.nomis_reference_codes where domain = 'SEX'),
      diet_info AS (select row_number() over (partition by offender_book_id) as rn,
                           offender_book_id,
-                          prisons.nomis_profile_codes.profile_code                  as code,
+                          prisons.nomis_profile_codes.profile_code          as code,
                           prisons.nomis_profile_codes.description
                    from prisons.nomis_offender_profile_details
                             left join prisons.nomis_profile_codes
@@ -55,51 +54,41 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                     prisons.nomis_profile_codes.description
              from prisons.nomis_offender_profile_details
                       left join prisons.nomis_profile_codes on prisons.nomis_offender_profile_details.profile_code =
-                                                       prisons.nomis_profile_codes.profile_code
+                                                               prisons.nomis_profile_codes.profile_code
              where prisons.nomis_offender_profile_details.profile_type = 'SEXO')
-SELECT o.offender_id_display                                  AS number,
-       ob.offender_book_id                                    AS id,
-       o.offender_id                                          AS offender_id,
-       o.root_offender_id                                     AS offender_root_id,
-       ob.agy_loc_id                                          AS establishment_id,
-       ob.living_unit_id                                      AS living_unit_id,
-       o.first_name                                           AS first_name,
-       o.middle_name                                          AS middle_name,
-       o.middle_name_2                                        AS middle_name_2,
-       o.last_name                                            AS last_name,
-       o.suffix                                               AS suffix,
-       (o.last_name || ', ' || substring(o.first_name, 1, 1)) AS name,
-       ob.request_name                                        AS requested_name,
-       o.birth_date                                           AS date_of_birth,
-       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))  AS age,
-       o.birth_place                                          AS birth_place,
-       o.sex_code                                             AS gender_code,
-       gender_domain.description                              AS gender,
+SELECT o.offender_id_display                                      AS number,
+       ob.offender_book_id                                        AS id,
+       o.offender_id                                              AS offender_id,
+       o.root_offender_id                                         AS offender_root_id,
+       ob.agy_loc_id                                              AS establishment_id,
+       ob.living_unit_id                                          AS living_unit_id,
+       o.first_name                                               AS first_name,
+       o.middle_name                                              AS middle_name,
+       o.middle_name_2                                            AS middle_name_2,
+       o.last_name                                                AS last_name,
+       o.suffix                                                   AS suffix,
+       (o.last_name || ', ' || substring(o.first_name, 1, 1))     AS name,
+       ob.request_name                                            AS requested_name,
+       o.birth_date                                               AS date_of_birth,
+       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))::int AS age,
+       o.birth_place                                              AS birth_place,
+       o.sex_code                                                 AS gender_code,
+       gender_domain.description                                  AS gender,
        CASE
            WHEN o.race_code = 'W8' then 'W3'
            WHEN o.race_code = 'O1' then 'A4'
-           ELSE o.race_code END                               AS ethnicity_code,
-       ethnicity_domain.description                           AS ethnicity,
-       prim_lang.language_code                                AS primary_language,
-       sec_lang.language_code                                 AS secondary_language,
-       pnc.identifier                                         AS pnc,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'LIFE'
-           ELSE (latest_sentence.years || '/' || latest_sentence.months || '/' ||
-                 latest_sentence.days) END                    AS sentence_length,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'Life'
-           ELSE (latest_sentence.years || ' years ' || latest_sentence.months || ' months ' || latest_sentence.days ||
-                 ' days') END                                 AS sentence_length_description,
-       nationality_info.code                                  AS nationality_code,
-       nationality_info.description                           AS nationality,
-       ofrel.profile_code                                     AS religion_code,
-       ofrel.description                                      AS religion,
-       latest_category.score                                  AS category,
-       diet_info.code                                         AS diet_code,
-       diet_info.description                                  AS diet,
-       sexo_info.code                                         AS sex_orientation_code,
-       sexo_info.description                                  AS sex_orientation
+           ELSE o.race_code END                                   AS ethnicity_code,
+       ethnicity_domain.description                               AS ethnicity,
+       prim_lang.language_code                                    AS primary_language,
+       pnc.identifier                                             AS pnc,
+       nationality_info.code                                      AS nationality_code,
+       nationality_info.description                               AS nationality,
+       ofrel.profile_code                                         AS religion_code,
+       ofrel.description                                          AS religion,
+       diet_info.code                                             AS diet_code,
+       diet_info.description                                      AS diet,
+       sexo_info.code                                             AS sex_orientation_code,
+       sexo_info.description                                      AS sex_orientation
 FROM prisons.nomis_offenders o
          JOIN prisons.nomis_offender_bookings ob ON o.offender_id = ob.offender_id
          LEFT JOIN ofrel ON ofrel.offender_book_id = ob.offender_book_id AND ofrel.rn = 1

--- a/migrations/test/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
+++ b/migrations/test/operationaldatastore/sql/V004__create-prisoner-prisoner-materialised-view.sql
@@ -3,7 +3,6 @@
 -- =================================================================
 
 CREATE SCHEMA IF NOT EXISTS domain;
-
 DROP MATERIALIZED VIEW IF EXISTS domain.prisoner_prisoner;
 
 CREATE MATERIALIZED VIEW domain.prisoner_prisoner AS
@@ -13,7 +12,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                       prisons.nomis_profile_codes.description
                FROM prisons.nomis_offender_profile_details
                         LEFT JOIN prisons.nomis_profile_codes ON prisons.nomis_profile_codes.profile_code =
-                                                         prisons.nomis_offender_profile_details.profile_code
+                                                                 prisons.nomis_offender_profile_details.profile_code
                where prisons.nomis_offender_profile_details.profile_type = 'RELF'),
      pnc AS (SELECT *, row_number() over (partition by offender_id order by offender_id_seq) as rn
              FROM prisons.nomis_offender_identifiers
@@ -29,7 +28,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                           where domain = 'ETHNICITY'),
      nationality_info AS (select row_number() over (partition by offender_book_id) as rn,
                                  offender_book_id,
-                                 prisons.nomis_profile_codes.profile_code                  as code,
+                                 prisons.nomis_profile_codes.profile_code          as code,
                                  prisons.nomis_profile_codes.description
                           from prisons.nomis_offender_profile_details
                                    left join prisons.nomis_profile_codes
@@ -39,7 +38,7 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
      gender_domain AS (SELECT code, domain, description from prisons.nomis_reference_codes where domain = 'SEX'),
      diet_info AS (select row_number() over (partition by offender_book_id) as rn,
                           offender_book_id,
-                          prisons.nomis_profile_codes.profile_code                  as code,
+                          prisons.nomis_profile_codes.profile_code          as code,
                           prisons.nomis_profile_codes.description
                    from prisons.nomis_offender_profile_details
                             left join prisons.nomis_profile_codes
@@ -55,51 +54,41 @@ WITH ofrel AS (SELECT row_number() over (partition by prisons.nomis_offender_pro
                     prisons.nomis_profile_codes.description
              from prisons.nomis_offender_profile_details
                       left join prisons.nomis_profile_codes on prisons.nomis_offender_profile_details.profile_code =
-                                                       prisons.nomis_profile_codes.profile_code
+                                                               prisons.nomis_profile_codes.profile_code
              where prisons.nomis_offender_profile_details.profile_type = 'SEXO')
-SELECT o.offender_id_display                                  AS number,
-       ob.offender_book_id                                    AS id,
-       o.offender_id                                          AS offender_id,
-       o.root_offender_id                                     AS offender_root_id,
-       ob.agy_loc_id                                          AS establishment_id,
-       ob.living_unit_id                                      AS living_unit_id,
-       o.first_name                                           AS first_name,
-       o.middle_name                                          AS middle_name,
-       o.middle_name_2                                        AS middle_name_2,
-       o.last_name                                            AS last_name,
-       o.suffix                                               AS suffix,
-       (o.last_name || ', ' || substring(o.first_name, 1, 1)) AS name,
-       ob.request_name                                        AS requested_name,
-       o.birth_date                                           AS date_of_birth,
-       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))  AS age,
-       o.birth_place                                          AS birth_place,
-       o.sex_code                                             AS gender_code,
-       gender_domain.description                              AS gender,
+SELECT o.offender_id_display                                      AS number,
+       ob.offender_book_id                                        AS id,
+       o.offender_id                                              AS offender_id,
+       o.root_offender_id                                         AS offender_root_id,
+       ob.agy_loc_id                                              AS establishment_id,
+       ob.living_unit_id                                          AS living_unit_id,
+       o.first_name                                               AS first_name,
+       o.middle_name                                              AS middle_name,
+       o.middle_name_2                                            AS middle_name_2,
+       o.last_name                                                AS last_name,
+       o.suffix                                                   AS suffix,
+       (o.last_name || ', ' || substring(o.first_name, 1, 1))     AS name,
+       ob.request_name                                            AS requested_name,
+       o.birth_date                                               AS date_of_birth,
+       EXTRACT(YEAR FROM AGE(CURRENT_TIMESTAMP, birth_date))::int AS age,
+       o.birth_place                                              AS birth_place,
+       o.sex_code                                                 AS gender_code,
+       gender_domain.description                                  AS gender,
        CASE
            WHEN o.race_code = 'W8' then 'W3'
            WHEN o.race_code = 'O1' then 'A4'
-           ELSE o.race_code END                               AS ethnicity_code,
-       ethnicity_domain.description                           AS ethnicity,
-       prim_lang.language_code                                AS primary_language,
-       sec_lang.language_code                                 AS secondary_language,
-       pnc.identifier                                         AS pnc,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'LIFE'
-           ELSE (latest_sentence.years || '/' || latest_sentence.months || '/' ||
-                 latest_sentence.days) END                    AS sentence_length,
-       CASE
-           WHEN latest_sentence.life_sentence_flag = 'Y' THEN 'Life'
-           ELSE (latest_sentence.years || ' years ' || latest_sentence.months || ' months ' || latest_sentence.days ||
-                 ' days') END                                 AS sentence_length_description,
-       nationality_info.code                                  AS nationality_code,
-       nationality_info.description                           AS nationality,
-       ofrel.profile_code                                     AS religion_code,
-       ofrel.description                                      AS religion,
-       latest_category.score                                  AS category,
-       diet_info.code                                         AS diet_code,
-       diet_info.description                                  AS diet,
-       sexo_info.code                                         AS sex_orientation_code,
-       sexo_info.description                                  AS sex_orientation
+           ELSE o.race_code END                                   AS ethnicity_code,
+       ethnicity_domain.description                               AS ethnicity,
+       prim_lang.language_code                                    AS primary_language,
+       pnc.identifier                                             AS pnc,
+       nationality_info.code                                      AS nationality_code,
+       nationality_info.description                               AS nationality,
+       ofrel.profile_code                                         AS religion_code,
+       ofrel.description                                          AS religion,
+       diet_info.code                                             AS diet_code,
+       diet_info.description                                      AS diet,
+       sexo_info.code                                             AS sex_orientation_code,
+       sexo_info.description                                      AS sex_orientation
 FROM prisons.nomis_offenders o
          JOIN prisons.nomis_offender_bookings ob ON o.offender_id = ob.offender_id
          LEFT JOIN ofrel ON ofrel.offender_book_id = ob.offender_book_id AND ofrel.rn = 1


### PR DESCRIPTION
Changes to prisoner_prisoner domain that came out of reconciliation testing against the same domain in Redshift.

While the operational datastore is only active in the dev environment I've used the opportunity to clear down the database so migrations can be applied from scratch to keep the code in the repo cleaner, rather than adding an extra migration to fix the issue.

* Update age column type with cast to integral type
* Remove columns that have incorrect implementation and require further analysis:
  - sentence_length
  - sentence_length_description
  - category
  - secondary_language columns.