### PR TITLE
DPR2-1751: Create a role that can be shared by users requiring read-only access to the ODS domain schema.

### DIFF
--- a/migrations/development/operationaldatastore/sql/V006__create-role-for-ods-domain-access.sql
+++ b/migrations/development/operationaldatastore/sql/V006__create-role-for-ods-domain-access.sql
@@ -1,0 +1,15 @@
+-- Create a role that can be granted to other users/roles
+CREATE ROLE fdw_access_domain_read_only;
+-- Allow connection to the database
+GRANT CONNECT ON DATABASE operational_db TO fdw_access_domain_read_only;
+-- Allow seeing objects in the domain schema
+GRANT USAGE ON SCHEMA domain TO fdw_access_domain_read_only;
+-- Allow selecting from all existing tables, views and materialised views in the domain schema
+GRANT SELECT ON ALL TABLES IN SCHEMA domain TO fdw_access_read_only;
+-- Ensure that the role can select from all new tables and views in the domain schema
+ALTER DEFAULT PRIVILEGES IN SCHEMA domain
+    GRANT SELECT ON TABLES TO fdw_access_read_only;
+
+-- You can create users and grant this role to them with SQL such as this:
+-- CREATE USER my_user WITH PASSWORD '...';
+-- GRANT fdw_access_domain_read_only TO my_user;

--- a/migrations/development/operationaldatastore/sql/V006__create-role-for-ods-domain-access.sql
+++ b/migrations/development/operationaldatastore/sql/V006__create-role-for-ods-domain-access.sql
@@ -5,10 +5,10 @@ GRANT CONNECT ON DATABASE operational_db TO fdw_access_domain_read_only;
 -- Allow seeing objects in the domain schema
 GRANT USAGE ON SCHEMA domain TO fdw_access_domain_read_only;
 -- Allow selecting from all existing tables, views and materialised views in the domain schema
-GRANT SELECT ON ALL TABLES IN SCHEMA domain TO fdw_access_read_only;
+GRANT SELECT ON ALL TABLES IN SCHEMA domain TO fdw_access_domain_read_only;
 -- Ensure that the role can select from all new tables and views in the domain schema
 ALTER DEFAULT PRIVILEGES IN SCHEMA domain
-    GRANT SELECT ON TABLES TO fdw_access_read_only;
+    GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
 
 -- You can create users and grant this role to them with SQL such as this:
 -- CREATE USER my_user WITH PASSWORD '...';

--- a/migrations/preproduction/operationaldatastore/sql/V006__create-role-for-ods-domain-access.sql
+++ b/migrations/preproduction/operationaldatastore/sql/V006__create-role-for-ods-domain-access.sql
@@ -1,0 +1,15 @@
+-- Create a role that can be granted to other users/roles
+CREATE ROLE fdw_access_domain_read_only;
+-- Allow connection to the database
+GRANT CONNECT ON DATABASE operational_db TO fdw_access_domain_read_only;
+-- Allow seeing objects in the domain schema
+GRANT USAGE ON SCHEMA domain TO fdw_access_domain_read_only;
+-- Allow selecting from all existing tables, views and materialised views in the domain schema
+GRANT SELECT ON ALL TABLES IN SCHEMA domain TO fdw_access_domain_read_only;
+-- Ensure that the role can select from all new tables and views in the domain schema
+ALTER DEFAULT PRIVILEGES IN SCHEMA domain
+    GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+
+-- You can create users and grant this role to them with SQL such as this:
+-- CREATE USER my_user WITH PASSWORD '...';
+-- GRANT fdw_access_domain_read_only TO my_user;

--- a/migrations/production/operationaldatastore/V006__create-role-for-ods-domain-access.sql
+++ b/migrations/production/operationaldatastore/V006__create-role-for-ods-domain-access.sql
@@ -1,0 +1,15 @@
+-- Create a role that can be granted to other users/roles
+CREATE ROLE fdw_access_domain_read_only;
+-- Allow connection to the database
+GRANT CONNECT ON DATABASE operational_db TO fdw_access_domain_read_only;
+-- Allow seeing objects in the domain schema
+GRANT USAGE ON SCHEMA domain TO fdw_access_domain_read_only;
+-- Allow selecting from all existing tables, views and materialised views in the domain schema
+GRANT SELECT ON ALL TABLES IN SCHEMA domain TO fdw_access_domain_read_only;
+-- Ensure that the role can select from all new tables and views in the domain schema
+ALTER DEFAULT PRIVILEGES IN SCHEMA domain
+    GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+
+-- You can create users and grant this role to them with SQL such as this:
+-- CREATE USER my_user WITH PASSWORD '...';
+-- GRANT fdw_access_domain_read_only TO my_user;

--- a/migrations/test/operationaldatastore/V006__create-role-for-ods-domain-access.sql
+++ b/migrations/test/operationaldatastore/V006__create-role-for-ods-domain-access.sql
@@ -1,0 +1,15 @@
+-- Create a role that can be granted to other users/roles
+CREATE ROLE fdw_access_domain_read_only;
+-- Allow connection to the database
+GRANT CONNECT ON DATABASE operational_db TO fdw_access_domain_read_only;
+-- Allow seeing objects in the domain schema
+GRANT USAGE ON SCHEMA domain TO fdw_access_domain_read_only;
+-- Allow selecting from all existing tables, views and materialised views in the domain schema
+GRANT SELECT ON ALL TABLES IN SCHEMA domain TO fdw_access_domain_read_only;
+-- Ensure that the role can select from all new tables and views in the domain schema
+ALTER DEFAULT PRIVILEGES IN SCHEMA domain
+    GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+
+-- You can create users and grant this role to them with SQL such as this:
+-- CREATE USER my_user WITH PASSWORD '...';
+-- GRANT fdw_access_domain_read_only TO my_user;


### PR DESCRIPTION
- Creates a role `fdw_access_domain_read_only` that has read-only access to the domains in the Operational DataStore
- You can then create a user for a DPS team and assign this role to it manually
- The idea is to cut down the number of commands you have to run manually to provision a user