### PR TITLE
DPR2-1821: Create new domain materialised views and schedule refreshes for them

### DIFF
--- a/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
+++ b/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
@@ -35,7 +35,7 @@ SELECT p.prison_id,
         where cat.prison_id = p.prison_id) as categories,
        (SELECT string_agg(o.name, ', ' ORDER BY o.name)
         FROM prisons.prisonregister_prison_operator op
-                 JOIN prisons.prisonregister_operator o on o.id = op.operator_id
+        JOIN prisons.prisonregister_operator o on o.id = op.operator_id
         WHERE op.prison_id = p.prison_id)  as operators
 FROM prisons.prisonregister_prison p;
 
@@ -54,7 +54,7 @@ SELECT sm.staff_id,
        aua.working_caseload_id as active_caseload_id,
        sm.status                  account_status
 FROM prisons.nomis_staff_members sm
-         JOIN prisons.nomis_staff_user_accounts aua ON sm.staff_id = aua.staff_id;
+JOIN prisons.nomis_staff_user_accounts aua ON sm.staff_id = aua.staff_id;
 
 -- =================================================================
 -- person.prisoner
@@ -73,13 +73,13 @@ SELECT o.offender_id_display as prisoner_number,
        i.description         as cell_location,
        l.id                  as location_uuid
 FROM prisons.nomis_offender_bookings ob
-         INNER JOIN prisons.nomis_offenders o
-                    ON ob.offender_id = o.offender_id AND ob.booking_seq = 1
-         LEFT JOIN prisons.nomis_agency_internal_locations i
-                   ON ob.living_unit_id = i.internal_location_id
-         LEFT JOIN prisons.locationsinsideprison_location l
-                   ON l.prison_id = ob.agy_loc_id
-                       AND concat(l.prison_id, concat('-', l.path_hierarchy)) = i.description;
+INNER JOIN prisons.nomis_offenders o
+    ON ob.offender_id = o.offender_id AND ob.booking_seq = 1
+LEFT JOIN prisons.nomis_agency_internal_locations i
+    ON ob.living_unit_id = i.internal_location_id
+LEFT JOIN prisons.locationsinsideprison_location l
+    ON l.prison_id = ob.agy_loc_id
+    AND concat(l.prison_id, concat('-', l.path_hierarchy)) = i.description;
 
 
 -- =================================================================
@@ -89,7 +89,11 @@ FROM prisons.nomis_offender_bookings ob
 CREATE SCHEMA regional;
 
 CREATE MATERIALIZED VIEW regional.area AS
-SELECT area_class, area_code, description, parent_area_code, active_flag
+SELECT area_class,
+       area_code,
+       description,
+       parent_area_code,
+       active_flag
 FROM prisons.nomis_areas;
 
 -- =================================================================

--- a/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
+++ b/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
@@ -18,8 +18,6 @@ FROM prisons.nomis_agency_locations;
 -- establishment.prison
 -- =================================================================
 
-CREATE SCHEMA establishment;
-
 CREATE MATERIALIZED VIEW establishment.prison AS
 SELECT p.prison_id,
        p.name,

--- a/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
+++ b/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
@@ -97,11 +97,12 @@ SELECT area_class,
 FROM prisons.nomis_areas;
 
 -- =================================================================
--- external.location
+-- external.locations
 -- =================================================================
 
 CREATE SCHEMA external;
-CREATE MATERIALIZED VIEW external.location AS
+
+CREATE MATERIALIZED VIEW external.locations AS
 SELECT agy_loc_id           as id,
        description          as name,
        agency_location_type as agency_type,

--- a/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
+++ b/migrations/development/operationaldatastore/sql/V008__create-domain-materialised-views.sql
@@ -1,0 +1,109 @@
+-- =================================================================
+-- establishment.establishment
+-- =================================================================
+
+CREATE SCHEMA establishment;
+
+CREATE MATERIALIZED VIEW establishment.establishment AS
+SELECT agy_loc_id           as id,
+       description          as name,
+       agency_location_type as agency_type,
+       area_code,
+       noms_region_code,
+       active_flag          as active
+FROM prisons.nomis_agency_locations;
+
+
+-- =================================================================
+-- establishment.prison
+-- =================================================================
+
+CREATE SCHEMA establishment;
+
+CREATE MATERIALIZED VIEW establishment.prison AS
+SELECT p.prison_id,
+       p.name,
+       p.active,
+       p.male,
+       p.female,
+       p.inactive_date,
+       p.contracted                        as contracted_out,
+       p.lthse                             as long_term_high_security_estate,
+       (SELECT string_agg(type, ', ' ORDER BY type)
+        FROM prisons.prisonregister_prison_type pt
+        where pt.prison_id = p.prison_id)  as types,
+       (SELECT string_agg(category, ', ' ORDER BY category)
+        FROM prisons.prisonregister_prison_category cat
+        where cat.prison_id = p.prison_id) as categories,
+       (SELECT string_agg(o.name, ', ' ORDER BY o.name)
+        FROM prisons.prisonregister_prison_operator op
+                 JOIN prisons.prisonregister_operator o on o.id = op.operator_id
+        WHERE op.prison_id = p.prison_id)  as operators
+FROM prisons.prisonregister_prison p;
+
+
+-- =================================================================
+-- staff.staff
+-- =================================================================
+
+CREATE SCHEMA staff;
+
+CREATE MATERIALIZED VIEW staff.staff AS
+SELECT sm.staff_id,
+       aua.username,
+       sm.first_name,
+       sm.last_name,
+       aua.working_caseload_id as active_caseload_id,
+       sm.status                  account_status
+FROM prisons.nomis_staff_members sm
+         JOIN prisons.nomis_staff_user_accounts aua ON sm.staff_id = aua.staff_id;
+
+-- =================================================================
+-- person.prisoner
+-- =================================================================
+
+CREATE SCHEMA person;
+
+CREATE MATERIALIZED VIEW person.prisoner AS
+SELECT o.offender_id_display as prisoner_number,
+       o.first_name,
+       o.last_name,
+       o.birth_date          as date_of_birth,
+       ob.offender_book_id   as latest_booking_id,
+       ob.booking_no         as latest_book_number,
+       ob.agy_loc_id         as prison_id,
+       i.description         as cell_location,
+       l.id                  as location_uuid
+FROM prisons.nomis_offender_bookings ob
+         INNER JOIN prisons.nomis_offenders o
+                    ON ob.offender_id = o.offender_id AND ob.booking_seq = 1
+         LEFT JOIN prisons.nomis_agency_internal_locations i
+                   ON ob.living_unit_id = i.internal_location_id
+         LEFT JOIN prisons.locationsinsideprison_location l
+                   ON l.prison_id = ob.agy_loc_id
+                       AND concat(l.prison_id, concat('-', l.path_hierarchy)) = i.description;
+
+
+-- =================================================================
+-- regional.area
+-- =================================================================
+
+CREATE SCHEMA regional;
+
+CREATE MATERIALIZED VIEW regional.area AS
+SELECT area_class, area_code, description, parent_area_code, active_flag
+FROM prisons.nomis_areas;
+
+-- =================================================================
+-- external.location
+-- =================================================================
+
+CREATE SCHEMA external;
+CREATE MATERIALIZED VIEW external.location AS
+SELECT agy_loc_id           as id,
+       description          as name,
+       agency_location_type as agency_type,
+       area_code,
+       noms_region_code,
+       active_flag          as active
+FROM prisons.nomis_agency_locations;

--- a/migrations/development/operationaldatastore/sql/V009__cron-refresh-domain-materialised-views.sql
+++ b/migrations/development/operationaldatastore/sql/V009__cron-refresh-domain-materialised-views.sql
@@ -1,0 +1,19 @@
+-- Create unique indexes (required to refresh materialised views concurrently) and a pg cron refresh schedule for each materialised view
+
+CREATE UNIQUE INDEX establishment_establishment_id_key ON establishment.establishment(id);
+SELECT cron.schedule ('refresh establishment.establishment','15 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY establishment.establishment');
+
+CREATE UNIQUE INDEX establishment_prison_prison_id_key ON establishment.prison(prison_id);
+SELECT cron.schedule ('refresh establishment.prison','30 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY establishment.prison');
+
+CREATE UNIQUE INDEX staff_staff_staff_id_key ON staff.staff(staff_id);
+SELECT cron.schedule ('refresh staff.staff','45 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY staff.staff');
+
+CREATE UNIQUE INDEX person_prisoner_offender_id_display_key ON person.prisoner(prisoner_number);
+SELECT cron.schedule ('refresh person.prisoner','0 3 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY person.prisoner');
+
+CREATE UNIQUE INDEX regional_area_area_code_key ON regional.area(area_code);
+SELECT cron.schedule ('refresh regional.area','15 3 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY regional.area');
+
+CREATE UNIQUE INDEX external_location_id_key ON external.location(id);
+SELECT cron.schedule ('refresh external.location','30 3 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY external.location');

--- a/migrations/development/operationaldatastore/sql/V009__cron-refresh-domain-materialised-views.sql
+++ b/migrations/development/operationaldatastore/sql/V009__cron-refresh-domain-materialised-views.sql
@@ -6,7 +6,7 @@ SELECT cron.schedule ('refresh establishment.establishment','15 2 * * *','REFRES
 CREATE UNIQUE INDEX establishment_prison_prison_id_key ON establishment.prison(prison_id);
 SELECT cron.schedule ('refresh establishment.prison','30 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY establishment.prison');
 
-CREATE UNIQUE INDEX staff_staff_staff_id_key ON staff.staff(staff_id);
+CREATE UNIQUE INDEX staff_staff_username_key ON staff.staff(username);
 SELECT cron.schedule ('refresh staff.staff','45 2 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY staff.staff');
 
 CREATE UNIQUE INDEX person_prisoner_offender_id_display_key ON person.prisoner(prisoner_number);

--- a/migrations/development/operationaldatastore/sql/V009__cron-refresh-domain-materialised-views.sql
+++ b/migrations/development/operationaldatastore/sql/V009__cron-refresh-domain-materialised-views.sql
@@ -15,5 +15,5 @@ SELECT cron.schedule ('refresh person.prisoner','0 3 * * *','REFRESH MATERIALIZE
 CREATE UNIQUE INDEX regional_area_area_code_key ON regional.area(area_code);
 SELECT cron.schedule ('refresh regional.area','15 3 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY regional.area');
 
-CREATE UNIQUE INDEX external_location_id_key ON external.location(id);
-SELECT cron.schedule ('refresh external.location','30 3 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY external.location');
+CREATE UNIQUE INDEX external_locations_id_key ON external.locations(id);
+SELECT cron.schedule ('refresh external.locations','30 3 * * *','REFRESH MATERIALIZED VIEW CONCURRENTLY external.locations');

--- a/migrations/development/operationaldatastore/sql/V010__give-domain-read-only-role-access-to-new-domain-views.sql
+++ b/migrations/development/operationaldatastore/sql/V010__give-domain-read-only-role-access-to-new-domain-views.sql
@@ -1,0 +1,18 @@
+-- Allow seeing objects in the domain schemas
+GRANT USAGE ON SCHEMA establishment, staff, person, regional, external TO fdw_access_domain_read_only;
+-- Allow selecting from all existing tables, views and materialised views in the domain schemas
+GRANT SELECT ON ALL TABLES IN SCHEMA establishment TO fdw_access_domain_read_only;
+GRANT SELECT ON ALL TABLES IN SCHEMA staff TO fdw_access_domain_read_only;
+GRANT SELECT ON ALL TABLES IN SCHEMA person TO fdw_access_domain_read_only;
+GRANT SELECT ON ALL TABLES IN SCHEMA regional TO fdw_access_domain_read_only;
+GRANT SELECT ON ALL TABLES IN SCHEMA external TO fdw_access_domain_read_only;
+-- Ensure that the role can select from all new tables and views in the domain schemas
+ALTER DEFAULT PRIVILEGES IN SCHEMA establishment GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+ALTER DEFAULT PRIVILEGES IN SCHEMA staff GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+ALTER DEFAULT PRIVILEGES IN SCHEMA person GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+ALTER DEFAULT PRIVILEGES IN SCHEMA regional GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+ALTER DEFAULT PRIVILEGES IN SCHEMA external GRANT SELECT ON TABLES TO fdw_access_domain_read_only;
+
+-- You can create users and grant this role to them with SQL such as this:
+-- CREATE USER my_user WITH PASSWORD '...';
+-- GRANT fdw_access_domain_read_only TO my_user;


### PR DESCRIPTION
- Create the new domain materialised views using the new naming convention, e.g. prisoner.prisoner instead of domains.prisoner_prisoner
- Add a unique index and cron refresh schedule for each of the new domain materialised views
- Give the fdw_access_domain_read_only role read-only access to the new domains